### PR TITLE
Expose setNameResolver to the interface of ParsecAsyncRequest.Builder

### DIFF
--- a/parsec-clients/src/main/java/com/yahoo/parsec/clients/DelegateNameResolver.java
+++ b/parsec-clients/src/main/java/com/yahoo/parsec/clients/DelegateNameResolver.java
@@ -1,3 +1,6 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
 package com.yahoo.parsec.clients;
 
 import com.google.common.base.Preconditions;

--- a/parsec-clients/src/main/java/com/yahoo/parsec/clients/DelegateNameResolver.java
+++ b/parsec-clients/src/main/java/com/yahoo/parsec/clients/DelegateNameResolver.java
@@ -1,0 +1,41 @@
+package com.yahoo.parsec.clients;
+
+import com.google.common.base.Preconditions;
+import com.ning.http.client.NameResolver;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * An implementation of {@link NameResolver} that will delegate the operations
+ * to a given instance of {@link ParsecNameResolver}.
+ */
+class DelegateNameResolver implements NameResolver {
+
+    private final ParsecNameResolver delegate;
+
+    /**
+     * Constructs a new resolver that will delegate the operations to the given
+     * {@link ParsecNameResolver}.
+     *
+     * @param delegate Delegate.
+     */
+    public DelegateNameResolver(ParsecNameResolver delegate) {
+        Preconditions.checkNotNull(delegate, "Delegate cannot be null");
+        this.delegate = delegate;
+    }
+
+    @Override
+    public InetAddress resolve(String name) throws UnknownHostException {
+        return delegate.resolve(name);
+    }
+
+    /**
+     * Gets the delegated name resolver.
+     *
+     * @return The delegate.
+     */
+    public ParsecNameResolver getDelegate() {
+        return delegate;
+    }
+}

--- a/parsec-clients/src/main/java/com/yahoo/parsec/clients/ParsecAsyncHttpRequest.java
+++ b/parsec-clients/src/main/java/com/yahoo/parsec/clients/ParsecAsyncHttpRequest.java
@@ -3,6 +3,7 @@
 
 package com.yahoo.parsec.clients;
 
+import com.google.common.base.Preconditions;
 import com.ning.http.client.*;
 import com.ning.http.client.cookie.Cookie;
 import com.ning.http.client.multipart.ByteArrayPart;
@@ -360,6 +361,15 @@ public class ParsecAsyncHttpRequest {
     }
 
     /**
+     * Gets the name resolver.
+     *
+     * @return Name resolver.
+     */
+    public ParsecNameResolver getNameResolver() {
+        return ((DelegateNameResolver) ningRequest.getNameResolver()).getDelegate();
+    }
+
+    /**
      * Static Builder class for {@link ParsecAsyncHttpRequest}.
      *
      * @author sho
@@ -491,6 +501,11 @@ public class ParsecAsyncHttpRequest {
         private List<Part> bodyParts;
 
         /**
+         * DNS name resolver.
+         */
+        private ParsecNameResolver nameResolver;
+
+        /**
          * Constructor.
          */
         public Builder() {
@@ -503,6 +518,7 @@ public class ParsecAsyncHttpRequest {
             uri = URI.create("http://localhost");
             acceptCompression = true;
             bodyParts = new ArrayList<>();
+            nameResolver = StandardNameResolver.getInstance();
         }
 
         /**
@@ -705,6 +721,8 @@ public class ParsecAsyncHttpRequest {
             for (Part part: bodyParts) {
                 ningRequestBuilder.addBodyPart(part);
             }
+
+            ningRequestBuilder.setNameResolver(new DelegateNameResolver(nameResolver));
 
             return new ParsecAsyncHttpRequest(this);
         }
@@ -981,6 +999,12 @@ public class ParsecAsyncHttpRequest {
          */
         public Builder setAcceptCompression(boolean acceptCompression) {
             this.acceptCompression = acceptCompression;
+            return this;
+        }
+
+        public Builder setNameResolver(ParsecNameResolver nameResolver) {
+            Preconditions.checkNotNull(nameResolver, "Name resolver cannot be null");
+            this.nameResolver = nameResolver;
             return this;
         }
     }

--- a/parsec-clients/src/main/java/com/yahoo/parsec/clients/ParsecNameResolver.java
+++ b/parsec-clients/src/main/java/com/yahoo/parsec/clients/ParsecNameResolver.java
@@ -1,0 +1,8 @@
+package com.yahoo.parsec.clients;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public interface ParsecNameResolver {
+    InetAddress resolve(String name) throws UnknownHostException;
+}

--- a/parsec-clients/src/main/java/com/yahoo/parsec/clients/RandomNameResolver.java
+++ b/parsec-clients/src/main/java/com/yahoo/parsec/clients/RandomNameResolver.java
@@ -1,3 +1,6 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
 package com.yahoo.parsec.clients;
 
 import java.net.InetAddress;

--- a/parsec-clients/src/main/java/com/yahoo/parsec/clients/RandomNameResolver.java
+++ b/parsec-clients/src/main/java/com/yahoo/parsec/clients/RandomNameResolver.java
@@ -1,0 +1,21 @@
+package com.yahoo.parsec.clients;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * An implementation of {@link ParsecNameResolver} that will randomly resolve
+ * an address among the list of results obtained from DNS.
+ * It is especially useful if your target server isn't behind a load balancer,
+ * and you want to balance the traffic among the available servers.
+ */
+public class RandomNameResolver implements ParsecNameResolver {
+
+    @Override
+    public InetAddress resolve(String name) throws UnknownHostException {
+        InetAddress[] addresses = InetAddress.getAllByName(name);
+        int addressIdx = ThreadLocalRandom.current().nextInt(addresses.length);
+        return addresses[addressIdx];
+    }
+}

--- a/parsec-clients/src/main/java/com/yahoo/parsec/clients/StandardNameResolver.java
+++ b/parsec-clients/src/main/java/com/yahoo/parsec/clients/StandardNameResolver.java
@@ -1,0 +1,28 @@
+package com.yahoo.parsec.clients;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * A standard implementation of {@link ParsecNameResolver} that will use
+ * {@code InetAddress.getByName} to obtain the address. It will typically return the
+ * first among the addresses returned from DNS.
+ */
+public class StandardNameResolver implements ParsecNameResolver {
+
+    private static final StandardNameResolver INSTANCE = new StandardNameResolver();
+
+    /**
+     * Get a shared static instance.
+     *
+     * @return A shared instance.
+     */
+    public static StandardNameResolver getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public InetAddress resolve(String name) throws UnknownHostException {
+        return InetAddress.getByName(name);
+    }
+}

--- a/parsec-clients/src/main/java/com/yahoo/parsec/clients/StandardNameResolver.java
+++ b/parsec-clients/src/main/java/com/yahoo/parsec/clients/StandardNameResolver.java
@@ -1,3 +1,6 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
 package com.yahoo.parsec.clients;
 
 import java.net.InetAddress;

--- a/parsec-clients/src/test/java/com/yahoo/parsec/clients/DelegateNameResolverTest.java
+++ b/parsec-clients/src/test/java/com/yahoo/parsec/clients/DelegateNameResolverTest.java
@@ -1,0 +1,37 @@
+package com.yahoo.parsec.clients;
+
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.InetAddress;
+
+/**
+ * Test class for {@link DelegateNameResolver}.
+ */
+public class DelegateNameResolverTest {
+
+    private ParsecNameResolver delegate;
+    private DelegateNameResolver nameResolver;
+
+    @BeforeMethod
+    public void setup() {
+        delegate = Mockito.mock(ParsecNameResolver.class);
+        nameResolver = new DelegateNameResolver(delegate);
+    }
+
+    @Test
+    public void testResolver() throws Exception {
+        InetAddress expectedAddress = InetAddress.getLoopbackAddress();
+        Mockito.when(delegate.resolve("www.google.com"))
+            .thenReturn(expectedAddress);
+
+        InetAddress address = nameResolver.resolve("www.google.com");
+        Assert.assertSame(expectedAddress, address);
+
+        Mockito.verify(delegate, Mockito.times(1))
+            .resolve("www.google.com");
+    }
+
+}

--- a/parsec-clients/src/test/java/com/yahoo/parsec/clients/DelegateNameResolverTest.java
+++ b/parsec-clients/src/test/java/com/yahoo/parsec/clients/DelegateNameResolverTest.java
@@ -1,3 +1,6 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
 package com.yahoo.parsec.clients;
 
 import org.mockito.Mockito;

--- a/parsec-clients/src/test/java/com/yahoo/parsec/clients/ParsecAsyncHttpRequestTest.java
+++ b/parsec-clients/src/test/java/com/yahoo/parsec/clients/ParsecAsyncHttpRequestTest.java
@@ -8,6 +8,9 @@ import com.ning.http.client.multipart.ByteArrayPart;
 import com.ning.http.client.multipart.FilePart;
 import com.ning.http.client.multipart.Part;
 import com.ning.http.client.multipart.StringPart;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -508,4 +511,16 @@ public class ParsecAsyncHttpRequestTest {
         assertEquals("[%2Bparam]", queryParams.get("encodeParam").toString());
         assertEquals("[param]", queryParams.get("normalParam").toString());
     }
+
+    @Test
+    public void testSetAndGetNameResolver() throws Exception {
+        // Test default value
+        assertSame(builder.build().getNameResolver(), StandardNameResolver.getInstance());
+
+        // Test set and get
+        ParsecNameResolver nameResolver = Mockito.mock(ParsecNameResolver.class);
+        assertSame(builder.setNameResolver(nameResolver), builder);
+        assertSame(builder.build().getNameResolver(), nameResolver);
+    }
+
 }

--- a/parsec-clients/src/test/java/com/yahoo/parsec/clients/RandomNameResolverTest.java
+++ b/parsec-clients/src/test/java/com/yahoo/parsec/clients/RandomNameResolverTest.java
@@ -1,3 +1,6 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
 package com.yahoo.parsec.clients;
 
 import org.testng.Assert;

--- a/parsec-clients/src/test/java/com/yahoo/parsec/clients/RandomNameResolverTest.java
+++ b/parsec-clients/src/test/java/com/yahoo/parsec/clients/RandomNameResolverTest.java
@@ -1,0 +1,27 @@
+package com.yahoo.parsec.clients;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.InetAddress;
+
+/**
+ * Test class for {@link RandomNameResolver}.
+ */
+public class RandomNameResolverTest {
+
+    private RandomNameResolver nameResolver;
+
+    @BeforeMethod
+    public void setup() {
+        nameResolver = new RandomNameResolver();
+    }
+
+    @Test
+    public void testResolver() throws Exception {
+        InetAddress address = nameResolver.resolve("www.google.com");
+        Assert.assertNotNull(address);
+    }
+
+}

--- a/parsec-clients/src/test/java/com/yahoo/parsec/clients/StandardNameResolverTest.java
+++ b/parsec-clients/src/test/java/com/yahoo/parsec/clients/StandardNameResolverTest.java
@@ -1,6 +1,7 @@
-package com.yahoo.parsec.clients;
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 
-import com.ning.http.client.NameResolver;
+package com.yahoo.parsec.clients;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;

--- a/parsec-clients/src/test/java/com/yahoo/parsec/clients/StandardNameResolverTest.java
+++ b/parsec-clients/src/test/java/com/yahoo/parsec/clients/StandardNameResolverTest.java
@@ -1,0 +1,37 @@
+package com.yahoo.parsec.clients;
+
+import com.ning.http.client.NameResolver;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.InetAddress;
+
+/**
+ * Test class for {@link StandardNameResolver}.
+ */
+public class StandardNameResolverTest {
+
+    private StandardNameResolver nameResolver;
+
+    @BeforeMethod
+    public void setup() {
+        nameResolver = new StandardNameResolver();
+    }
+
+    @Test
+    public void testResolver() throws Exception {
+        InetAddress address = nameResolver.resolve("www.google.com");
+        Assert.assertNotNull(address);
+    }
+
+    @Test
+    public void testGetInstance() {
+        StandardNameResolver nameResolver1 = StandardNameResolver.getInstance();
+        StandardNameResolver nameResolver2 = StandardNameResolver.getInstance();
+        Assert.assertNotNull(nameResolver1);
+        Assert.assertSame(nameResolver1, nameResolver2);
+    }
+
+}


### PR DESCRIPTION
By default, the ning http client will use InetAddress.getByName() to obtain the IP address. It will always return the first IP among the DNS query result.
It works fine if the target server is behind VIP, but not otherwise.
Therefore, I want to expose the setNameResolver interface so that user can decide which kind of name resolver to used based on whether the target server is behind a VIP.

