### PR TITLE
quick fix removed function

### DIFF
--- a/parsec-clients/src/main/java/com/yahoo/parsec/clients/ParsecCompletableFuture.java
+++ b/parsec-clients/src/main/java/com/yahoo/parsec/clients/ParsecCompletableFuture.java
@@ -3,6 +3,7 @@
 
 package com.yahoo.parsec.clients;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -44,7 +45,8 @@ public class ParsecCompletableFuture<T> extends CompletableFuture<T> {
                 public void onFailure(Throwable t) {
                     completeExceptionally(t);
                 }
-            });
+            },
+            MoreExecutors.directExecutor());
         }
     }
 


### PR DESCRIPTION
The function `Futures#addCallback(ListenableFuture, FutureCallback)` was deprecated from version 22.0, and removed from version 26-jre. Quickly fix with the manual description.

https://google.github.io/guava/releases/22.0/api/docs/com/google/common/util/concurrent/Futures.html#addCallback-com.google.common.util.concurrent.ListenableFuture-com.google.common.util.concurrent.FutureCallback-
> For identical behavior, pass MoreExecutors.directExecutor(), but consider whether another executor would be safer, as discussed in the ListenableFuture.addListener documentation.
