### PR TITLE
Prepend profiling logs with UTC date/time

### DIFF
--- a/parsec-clients/src/main/java/com/yahoo/parsec/clients/ParsecClientProfilingLogUtil.java
+++ b/parsec-clients/src/main/java/com/yahoo/parsec/clients/ParsecClientProfilingLogUtil.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.Map;
 
 
@@ -77,6 +78,7 @@ public final class ParsecClientProfilingLogUtil {
         // prepare log data
         //
         long now = System.currentTimeMillis();
+        Instant timeInUtcDateTime = Instant.ofEpochMilli(now);
         BigDecimal timeInSecond = new BigDecimal(now).divide(BigDecimal.valueOf(DateUtils.MILLIS_PER_SECOND));
         String contentLength = "";
         String origin = "";
@@ -104,6 +106,7 @@ public final class ParsecClientProfilingLogUtil {
         String srcUrl = "";
 
         StringBuilder stringBuilder = new StringBuilder()
+                .append(timeInUtcDateTime).append(" ")
                 .append("time=").append(timeInSecond).append(", ")
                 .append("req_url=").append(reqUrl).append(", ")
                 .append("req_host_header=").append(reqHostHeader).append(", ")

--- a/parsec-clients/src/main/java/com/yahoo/parsec/clients/ParsecClientProfilingLogUtil.java
+++ b/parsec-clients/src/main/java/com/yahoo/parsec/clients/ParsecClientProfilingLogUtil.java
@@ -77,9 +77,9 @@ public final class ParsecClientProfilingLogUtil {
         //
         // prepare log data
         //
-        long now = System.currentTimeMillis();
-        Instant timeInUtcDateTime = Instant.ofEpochMilli(now);
-        BigDecimal timeInSecond = new BigDecimal(now).divide(BigDecimal.valueOf(DateUtils.MILLIS_PER_SECOND));
+        Instant timeInUtcDateTime = Instant.now();
+        BigDecimal timeInSecond = new BigDecimal(timeInUtcDateTime.toEpochMilli())
+            .divide(BigDecimal.valueOf(DateUtils.MILLIS_PER_SECOND));
         String contentLength = "";
         String origin = "";
         int respCode = -1;


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The profiling logs doesn't seem to be parsed properly by Splunk.
Ex. 
<img width="1552" alt="截圖 2022-06-09 下午12 14 58" src="https://user-images.githubusercontent.com/45912965/172762924-bf49ac4f-f10d-4b63-aedb-3be2bee56751.png">
It could be no correct date/time logging format on logs, so some contiguous logs are combined into one by Splunk.
Ref doc: https://git.ouryahoo.com/pages/BlackHawk/comms-splunk-documentation/DOCS/standards/splunk-logging-standards/#datetime-logging-format
So prepend the profiling logs with UTC date/time
