### PR TITLE
build(dep): upgrade jackson-databind to 2.13.3 fox fixing the vulnerabilities

### DIFF
--- a/parsec-logging/build.gradle
+++ b/parsec-logging/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'groovy'
 
 dependencies{
     compile group: 'org.slf4j'           , name: 'slf4j-api'         , version: '1.7.12'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.7'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.3'
 
     testCompile group: 'org.spockframework', name: 'spock-core'     , version: '1.0-groovy-2.4'
     testCompile group: 'ch.qos.logback'    , name: 'logback-classic', version: '1.1.3'


### PR DESCRIPTION
# Change List
- build(dep): upgrade jackson-databind to 2.13.3 fox fixing the vulnerabilities listed in https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.9.7

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
